### PR TITLE
Add Roboflow inference support and custom trained balloon detection models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,6 +161,3 @@ cython_debug/
 
 # Test Files
 test.py
-
-# Custom Balloon Detection Model - Training Dataset
-Blimp_Yolo_v8_Custom.v1i.yolov8

--- a/.gitignore
+++ b/.gitignore
@@ -161,3 +161,6 @@ cython_debug/
 
 # Test Files
 test.py
+
+# Custom Balloon Detection Model - Training Dataset
+Blimp_Yolo_v8_Custom.v1i.yolov8

--- a/src/inference_det/detection.py
+++ b/src/inference_det/detection.py
@@ -1,0 +1,20 @@
+import inference
+from inference import InferencePipeline
+from inference.core.interfaces.stream.sinks import render_boxes
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
+ROBOFLOW_API_KEY = os.getenv("ROBOFLOW_API_KEY")
+
+# initialize a pipeline object
+pipeline = InferencePipeline.init(
+    model_id="blimp_yolo_v8_custom/1", # Roboflow model to use
+    video_reference=0, # Path to video, device id (int, usually 0 for built in webcams), or RTSP stream url
+    on_prediction=render_boxes, # Function to run after each prediction
+    api_key=ROBOFLOW_API_KEY, 
+)
+pipeline.start()
+pipeline.join()
+
+

--- a/src/inference_det/detection.py
+++ b/src/inference_det/detection.py
@@ -4,6 +4,8 @@ from inference.core.interfaces.stream.sinks import render_boxes
 import os
 from dotenv import load_dotenv
 
+# THIS SCRIPT REQUIRES INTERNET ACCESS TO WORK
+
 load_dotenv()
 ROBOFLOW_API_KEY = os.getenv("ROBOFLOW_API_KEY")
 

--- a/src/ultralytics_track/README.md
+++ b/src/ultralytics_track/README.md
@@ -1,0 +1,13 @@
+# ANKA Balloon Detection Model Details
+
+## anka_v0.pt,
+
+- Trained on [Blimp_Yolov8_Custom Dataset](https://universe.roboflow.com/prasku-mxsdv/blimp_yolo_v8_custom)
+- Based on `yolov8m.pt`
+
+## anka_v1.pt
+
+- Trained on [Balloon_2 Dataset](https://universe.roboflow.com/balloon-mytgt/balloon2-wklvy)
+- Based o `yolov8n.pt`
+
+For differences between different yolov8 models such as `yolov8m.pt` and `yolov8n.pt`, visit (Ultralytics Documentation)[https://docs.ultralytics.com/models/yolov8/#performance-metrics]

--- a/src/ultralytics_track/track.py
+++ b/src/ultralytics_track/track.py
@@ -2,32 +2,11 @@ from ultralytics import YOLO
 import cv2
 import os
 
+# Load YOLOV8 Model
 
-# load yolov8 model
-model_filename = 'yolov8n.pt'
+# model_filename = 'yolov8n.pt'
+model_filename = 'anka_v0.pt'
 model_path = os.path.join(os.path.dirname(__file__), "models", model_filename)
 model = YOLO(model_path)
 
-# load video
-video_path = os.path.join(os.path.dirname(__file__), "test.mp4") # Replace variable with 0 for webcam
-cap = cv2.VideoCapture(video_path)
-
-ret = True
-# read frames
-while ret:
-    ret, frame = cap.read()
-    
-    if ret:
-        # detect objects
-        # track objects
-        results = model.track(frame, persist=True)
-
-        # plot results
-        # cv2.rectangle
-        # cv2.putText
-        frame_ = results[0].plot()
-
-        # visualize
-        cv2.imshow('frame', frame_)
-        if cv2.waitKey(25) & 0xFF == ord('q'):
-            break
+results = model.track(source=0, show=True)

--- a/src/ultralytics_track/track.py
+++ b/src/ultralytics_track/track.py
@@ -3,9 +3,7 @@ import cv2
 import os
 
 # Load YOLOV8 Model
-
-# model_filename = 'yolov8n.pt'
-model_filename = 'anka_v0.pt'
+model_filename = 'anka_v1.pt'
 model_path = os.path.join(os.path.dirname(__file__), "models", model_filename)
 model = YOLO(model_path)
 


### PR DESCRIPTION
**Changes:**

- Added `inference_det` which can run on Hosted Roboflow API using available models on the web. Requires internet connection at all times.
- Refactored `ultralytics_track` code to remove unnecessary code.
- Trained 2 custom yolov8 models called `anka_v0.pt` and `anka_v1.pt`. As of now, `anka_v1` outperforms its predecessor in terms of detecting balloons. You can find more info on the related README.md file.